### PR TITLE
Allow spaces in text policy word list

### DIFF
--- a/src/Validators/TextPolicyValidator.php
+++ b/src/Validators/TextPolicyValidator.php
@@ -159,7 +159,7 @@ class TextPolicyValidator {
 	private function composeRegex( array $wordArray ): string {
 		$quotedWords = array_map(
 			function ( string $word ) {
-				return preg_quote( $word, '#' );
+				return str_replace( ' ', '\\s*', preg_quote( trim( $word ), '#' ) );
 			},
 			$wordArray
 		);

--- a/tests/System/TextPolicyValidatorTest.php
+++ b/tests/System/TextPolicyValidatorTest.php
@@ -112,6 +112,9 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 			[ 'Heil Hitler!' ],
 			[ 'Duhamsterfresse!!!' ],
 			[ 'Alles nur HAMSTERFRESSEN!!!!!!!!1111111111' ],
+			[ 'SiegHeil' ],
+			[ 'Sieg Heil' ],
+			[ "Sieg    \n\tHeil!" ]
 		];
 	}
 
@@ -198,7 +201,8 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 				'deppen',
 				'hitler',
 				'hamsterfresse',
-				'arsch'
+				'arsch',
+				'sieg heil'
 			] );
 		$textPolicyValidator->addWhiteWordsFromArray(
 			[


### PR DESCRIPTION
Interpret spaces as "those two words should (not) be written after each
other".