### PR TITLE
Improve text policy test

### DIFF
--- a/tests/System/TextPolicyValidatorTest.php
+++ b/tests/System/TextPolicyValidatorTest.php
@@ -78,7 +78,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	public function testHamlessContentWithDns(): void {
+	public function testHarmlessContentWithDns(): void {
 		$this->skipIfNoInternet();
 
 		if ( checkdnsrr( 'some-non-existing-domain-drfeszrfdaesr.sdferdyerdhgty', 'A' ) ) {

--- a/tests/System/TextPolicyValidatorTest.php
+++ b/tests/System/TextPolicyValidatorTest.php
@@ -61,7 +61,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	public function testWhenGivenHarmlessComment_validatorReturnsTrue( string $commentToTest ): void {
 		$this->skipIfNoInternet();
 
-		$textPolicyValidator = new TextPolicyValidator();
+		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
 
 		$this->assertTrue( $textPolicyValidator->hasHarmlessContent(
 			$commentToTest,
@@ -197,7 +197,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 			[
 				'deppen',
 				'hitler',
-				'fresse',
+				'hamsterfresse',
 				'arsch'
 			] );
 		$textPolicyValidator->addWhiteWordsFromArray(


### PR DESCRIPTION
Use `TextPolicyValidator` with actual rules when testing with harmless content.
Fix typo in test method.