### PR TITLE
Always validate postcode length

### DIFF
--- a/src/Validators/AddressValidator.php
+++ b/src/Validators/AddressValidator.php
@@ -66,14 +66,12 @@ class AddressValidator {
 			$violations[] = $this->validateFieldLength( $streetAddress, self::SOURCE_STREET_ADDRESS );
 		}
 
-		if ( isset( $this->countriesPostcodePatterns[$countryCode] ) ) {
-			$violations[] = $this->validatePostalCode( $this->countriesPostcodePatterns[$countryCode], $postalCode );
-		} else {
-			$postalCodeLengthViolation = $this->validateFieldLength( $postalCode, self::SOURCE_POSTAL_CODE );
-			if ( $postalCodeLengthViolation === null ) {
-				$violations[] = $this->validatePostalCode( $this->addressPatterns['postcode'], $postalCode );
+		$violations[] = $postalCodeLengthViolation = $this->validateFieldLength( $postalCode, self::SOURCE_POSTAL_CODE );
+		if ( $postalCodeLengthViolation === null ) {
+			if ( isset( $this->countriesPostcodePatterns[$countryCode] ) ) {
+				$violations[] = $this->validatePostalCode( $this->countriesPostcodePatterns[$countryCode], $postalCode );
 			} else {
-				$violations[] = $postalCodeLengthViolation;
+				$violations[] = $this->validatePostalCode( $this->addressPatterns['postcode'], $postalCode );
 			}
 		}
 


### PR DESCRIPTION
The previous code came from a time where not all countries had regex
checks. Now that all the countries have patterns (albeit primitive ones
like `/^.+$/`), we need to always check for length before validating the
pattern, otherwise postcodes that are too long will slip through.

Ticket: https://phabricator.wikimedia.org/T350676
