### PR TITLE
Create alternative to CanValidateField trait

### DIFF
--- a/src/CanValidateField.php
+++ b/src/CanValidateField.php
@@ -5,8 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\FunValidators;
 
 /**
- * @deprecated this trait is used in other repositories and cannot be tested here properly,
- * thus it should be turned into a helper class instead or get the behaviour extracted in another way
+ * @deprecated Use {@see WMDE\FunValidators\ValidationResult::setSource()} instead
  */
 trait CanValidateField {
 

--- a/src/ConstraintViolation.php
+++ b/src/ConstraintViolation.php
@@ -33,6 +33,9 @@ class ConstraintViolation {
 	}
 
 	public function setSource( string $source ): void {
+		if ( $this->source && $this->source !== $source ) {
+			trigger_error( 'Source is already set, overwriting it will be a logic exception in the future', E_USER_DEPRECATED );
+		}
 		$this->source = $source;
 	}
 

--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -30,4 +30,25 @@ class ValidationResult {
 		return $this->violations;
 	}
 
+	/**
+	 * Set source of an error in all violations.
+	 *
+	 * This method is meant for validation results that come from one source,
+	 * e.g. a validator like {@see WMDE\FunValidators\Validators\RequiredFieldValidator}
+	 * or {@see WMDE\FunValidators\Validators\StringLengthValidator}
+	 *
+	 * DO NOT call it on validation results that come from validators
+	 * that validate several sources. In those cases, the responsibility to
+	 * set the source is with the validator and not its calling code.
+	 */
+	public function setSource( string $sourceName ): self {
+		foreach ( $this->violations as $violation ) {
+			$violation->setSource( $sourceName );
+		}
+		return $this;
+	}
+
+	public function getFirstViolation(): ?ConstraintViolation {
+		return $this->violations[0] ?? null;
+	}
 }

--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -31,6 +31,13 @@ class ValidationResult {
 	}
 
 	/**
+	 * @deprecated Use {@see setSourceForAllViolations()} instead
+	 */
+	public function setSource( string $sourceName ): self {
+		return $this->setSourceForAllViolations( $sourceName );
+	}
+
+	/**
 	 * Set source of an error in all violations.
 	 *
 	 * This method is meant for validation results that come from one source,
@@ -41,7 +48,7 @@ class ValidationResult {
 	 * that validate several sources. In those cases, the responsibility to
 	 * set the source is with the validator and not its calling code.
 	 */
-	public function setSource( string $sourceName ): self {
+	public function setSourceForAllViolations( string $sourceName ): self {
 		foreach ( $this->violations as $violation ) {
 			$violation->setSource( $sourceName );
 		}

--- a/tests/Unit/ConstraintViolationTest.php
+++ b/tests/Unit/ConstraintViolationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\FunValidators\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use WMDE\FunValidators\ConstraintViolation;
+
+#[CoversClass( ConstraintViolation::class )]
+class ConstraintViolationTest extends TestCase {
+	public function testConstructorSetsProperties(): void {
+			$constraintViolation = new ConstraintViolation( "1nval1d", "no_mix_of_numbers_and_letters", "username" );
+
+			$this->assertSame( 'no_mix_of_numbers_and_letters', $constraintViolation->getMessageIdentifier() );
+			$this->assertSame( '1nval1d', $constraintViolation->getValue() );
+			$this->assertSame( 'username', $constraintViolation->getSource() );
+	}
+
+	public function testSetSource(): void {
+		$constraintViolation = new ConstraintViolation( "1nval1d", "no_mix_of_numbers_and_letters" );
+
+		$constraintViolation->setSource( 'access_code' );
+
+			$this->assertSame( 'access_code', $constraintViolation->getSource() );
+	}
+
+	/**
+	 * We'll change this to an exception check when our other libraries don't trigger deprecations any more
+	 */
+	public function testSetSourceDeprecatesOverridingExistingSource(): void {
+		$constraintViolation = new ConstraintViolation( "1nval1d", "no_mix_of_numbers_and_letters", 'username' );
+		$hasTriggeredDeprecation = false;
+		// @phpstan-ignore-next-line argument.type
+		set_error_handler( static function ()use( &$hasTriggeredDeprecation ){
+			$hasTriggeredDeprecation = true;
+		}, E_USER_DEPRECATED );
+
+		$constraintViolation->setSource( 'access_code' );
+
+		restore_error_handler();
+		$this->assertTrue( $hasTriggeredDeprecation );
+	}
+
+	/**
+	 * We'll change this to an exception check when our other libraries don't trigger deprecations any more
+	 */
+	public function testSetSourceAllowsOverridingWhenSourceNameMatches(): void {
+		$constraintViolation = new ConstraintViolation( "1nval1d", "no_mix_of_numbers_and_letters", 'username' );
+		$hasTriggeredDeprecation = false;
+		// @phpstan-ignore-next-line argument.type
+		set_error_handler( static function ()use( &$hasTriggeredDeprecation ){
+			$hasTriggeredDeprecation = true;
+		}, E_USER_DEPRECATED );
+
+		$constraintViolation->setSource( 'username' );
+
+		restore_error_handler();
+		$this->assertFalse( $hasTriggeredDeprecation );
+	}
+
+}

--- a/tests/Unit/ValidationResultTest.php
+++ b/tests/Unit/ValidationResultTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\FunValidators\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use WMDE\FunValidators\ConstraintViolation;
+use WMDE\FunValidators\ValidationResult;
+
+#[CoversClass( ValidationResult::class )]
+class ValidationResultTest extends TestCase {
+	public function testResultWithoutViolationsIsSuccessful(): void {
+		$result = new ValidationResult();
+
+		$this->assertTrue( $result->isSuccessful() );
+		$this->assertFalse( $result->hasViolations() );
+	}
+
+	public function testResultWithViolationsIsNotSuccessful(): void {
+		$violation1 = new ConstraintViolation( 'value?', 'test_message_1' );
+		$violation2 = new ConstraintViolation( 'value!', 'test_message_2' );
+		$result = new ValidationResult( $violation1, $violation2 );
+
+		$this->assertFalse( $result->isSuccessful() );
+		$this->assertTrue( $result->hasViolations() );
+		$this->assertSame( [ $violation1, $violation2 ], $result->getViolations() );
+	}
+
+	public function testSetSourceSetsSourceForAllViolations(): void {
+		$violation1 = new ConstraintViolation( 'value?', 'test_message_1' );
+		$violation2 = new ConstraintViolation( 'value!', 'test_message_2' );
+		$result = new ValidationResult( $violation1, $violation2 );
+
+		$result->setSource( 'a_test_field' );
+
+		$this->assertSame( 'a_test_field', $violation1->getSource() );
+		$this->assertSame( 'a_test_field', $violation2->getSource() );
+	}
+
+	public function testGetFirstViolationReturnsFirstViolation(): void {
+		$violation1 = new ConstraintViolation( 'value?', 'test_message_1' );
+		$violation2 = new ConstraintViolation( 'value!', 'test_message_2' );
+		$result = new ValidationResult( $violation1, $violation2 );
+
+		$this->assertSame( $violation1, $result->getFirstViolation() );
+	}
+
+	public function testGetFirstViolationReturnsNullWhenThereAreNoViolations(): void {
+		$result = new ValidationResult();
+
+		$this->assertNull( $result->getFirstViolation() );
+	}
+
+}

--- a/tests/Unit/ValidationResultTest.php
+++ b/tests/Unit/ValidationResultTest.php
@@ -28,12 +28,12 @@ class ValidationResultTest extends TestCase {
 		$this->assertSame( [ $violation1, $violation2 ], $result->getViolations() );
 	}
 
-	public function testSetSourceSetsSourceForAllViolations(): void {
+	public function testSetSourceForAllViolationsChangesAllViolations(): void {
 		$violation1 = new ConstraintViolation( 'value?', 'test_message_1' );
 		$violation2 = new ConstraintViolation( 'value!', 'test_message_2' );
 		$result = new ValidationResult( $violation1, $violation2 );
 
-		$result->setSource( 'a_test_field' );
+		$result->setSourceForAllViolations( 'a_test_field' );
 
 		$this->assertSame( 'a_test_field', $violation1->getSource() );
 		$this->assertSame( 'a_test_field', $violation2->getSource() );


### PR DESCRIPTION
The trait was meant to "wrap" single-source validators which add a
ValidationResult with zero or more violations. The trait is supposed to
add a source name and return only the first violation for cases where we
don't care about each individual violation from a validator. But we
aren't using the trait in this repo and provide it for other code, which
is bad practice, because it's the wrong OOP pattern.

To replace the trait, we add utility methods to ValidationResult to set
the source and get the first violation. Calling code should replace

    $violation = $this->getFieldViolation($result, 'source_name');

with

    $violation = $result->setSource('source_name')->getFirstViolation();

Ticket: https://phabricator.wikimedia.org/T383340
